### PR TITLE
gov-framework: unify and update reference links

### DIFF
--- a/framework-v1/README.md
+++ b/framework-v1/README.md
@@ -13,9 +13,11 @@ Links:
   - [V1 Governance Framework](./gov-framework.md)
   - [Presentation](https://docs.google.com/presentation/d/1TxEtvXKTblO0kY7pEn54zHvPs2bX-g3i8twJCZatFGE/edit?pli=1#slide=id.g1f5a05682c7_1_60)
 
+- [NEAR Constitution](./constitution.md)
 - [Elections](#Elections)
   - [voting details](./elections-voting.md)
 - [Community Treasury](./community-treasury.md)
+- [Code of Conduct](./code-of-conduct.md)
 - [List of links and documents](https://thewiki.near.page/gwg-docs)
 
 ## Important Dates
@@ -151,8 +153,6 @@ After the election results are announced, the elected representatives will conve
 1. [Ops Manual](https://near-ndc.notion.site/NDC-V1-Ops-Manual-914bf75675284daf8314e1a05c0a2eea)
 1. [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0/edit?pli=1) (outdated)
 1. [NDC Trust](https://bafybeic5s7qbf3dlbwqesv4byzc6llwpfx2kq36xzwfknu7sskxlanellm.ipfs.nftstorage.link/)
-1. [NEAR Constitution](./constitution.md)
-1. [Code of Conduct](./code-of-conduct.md)
 1. [Declaration of Transparency and Accountability](https://bafkreid3vx2tivdlwkivezalhkscxnxakirw5nuunxce3b6ivtx4j6ac44.ipfs.nftstorage.link/)
 1. [Fair Voting Policy](https://bafkreiapsavs6hrc6aomzagub7aumogkfbjewlo2tvwzesr4myshlecfqy.ipfs.nftstorage.link)
 1. [Whistleblower program](https://medium.com/@neardigitalcollective/introducing-ndc-whistleblower-bounty-program-d4fe1b9fc5a0)

--- a/framework-v1/README.md
+++ b/framework-v1/README.md
@@ -147,10 +147,26 @@ Election results will be announced on the NDC’s Medium, Telegram, and Discord 
 
 After the election results are announced, the elected representatives will convene for the first time in the first NDC governance town hall, where we will hear from elected members from the three branches of NDC governance.
 
-## More links
+## References
 
-1. [fair-voting-policy](https://bafkreiapsavs6hrc6aomzagub7aumogkfbjewlo2tvwzesr4myshlecfqy.ipfs.nftstorage.link)
-2. [Registry docs](https://github.com/near-ndc/i-am-human/tree/master/contracts/registry#readme)
-3. [Elections smart contract](https://github.com/near-ndc/voting-v1/tree/master/elections)
-4. [I Am Human (IAH)](https://i-am-human.gitbook.io/i-am-human-docs/)
-5. [Whistleblower program](https://medium.com/@neardigitalcollective/introducing-ndc-whistleblower-bounty-program-d4fe1b9fc5a0)
+1. [NDC Overview Slides](https://docs.google.com/presentation/d/1YFzsBRB-UcZYN93tDVEHUGE7uGx2OuW61PnXsNMYgPU/edit?usp=sharing)
+1. [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0/edit?pli=1) (outdated)
+1. [NDC Trust](https://bafybeic5s7qbf3dlbwqesv4byzc6llwpfx2kq36xzwfknu7sskxlanellm.ipfs.nftstorage.link/)
+1. [NEAR Constitution](./constitution.md)
+1. [Code of Conduct](https://medium.com/near-digital-collective/ndc-code-of-conduct-89589dd137ba)
+1. [Declaration of Transparency and Accountability](https://bafkreid3vx2tivdlwkivezalhkscxnxakirw5nuunxce3b6ivtx4j6ac44.ipfs.nftstorage.link/)
+1. [Fair Voting Policy](https://bafkreiapsavs6hrc6aomzagub7aumogkfbjewlo2tvwzesr4myshlecfqy.ipfs.nftstorage.link)
+1. [Whistleblower program](https://medium.com/@neardigitalcollective/introducing-ndc-whistleblower-bounty-program-d4fe1b9fc5a0)
+1. [Voting Body](https://github.com/near-ndc/voting-v1/tree/master/voting_body) contract implementation.
+1. [Congress](https://github.com/near-ndc/voting-v1/tree/master/congress) (HoM, CoA, TC) contract implementation.
+1. [Elections smart contract](https://github.com/near-ndc/voting-v1/tree/master/elections)
+
+### Tools:
+
+- [Astra++](https://near.org/astraplusplus.ndctools.near/widget/home?page=congress) - Congress, Voting Body, DAOs
+- [NDC Docs](https://near.org/neardigitalcollective.near/widget/NDCDocs) - post/edit final docs
+- [Easy Poll](https://near.org/easypoll-v0.ndc-widgets.near/widget/EasyPoll?page=official_polls) - Community pulse and sentiment
+- [NDC Chatbot](https://ndc-chatbot.nearhub.club/) - Ask questions
+- [Kudos](https://near.org/kudos.ndctools.near/widget/NDC.Kudos.Main) - appreciation and recognition
+- [I Am Human (IAH)](https://i-am-human.gitbook.io/i-am-human-docs/)
+- [I Am Human Registry](https://github.com/near-ndc/i-am-human/tree/master/contracts/registry#readme)

--- a/framework-v1/README.md
+++ b/framework-v1/README.md
@@ -149,7 +149,7 @@ After the election results are announced, the elected representatives will conve
 
 ## References
 
-1. [NDC Overview]( https://docs.google.com/presentation/d/1Vm12P-vMtaDHvK-gtFroW6PAQ6fis32SiGHbW2qYaGQ/edit?usp=sharing)
+1. [NDC Overview](https://docs.google.com/presentation/d/1YFzsBRB-UcZYN93tDVEHUGE7uGx2OuW61PnXsNMYgPU/edit?usp=sharing)
 1. [Ops Manual](https://near-ndc.notion.site/NDC-V1-Ops-Manual-914bf75675284daf8314e1a05c0a2eea)
 1. [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0/edit?pli=1) (outdated)
 1. [NDC Trust](https://bafybeic5s7qbf3dlbwqesv4byzc6llwpfx2kq36xzwfknu7sskxlanellm.ipfs.nftstorage.link/)

--- a/framework-v1/README.md
+++ b/framework-v1/README.md
@@ -15,8 +15,6 @@ Links:
 
 - [Elections](#Elections)
   - [voting details](./elections-voting.md)
-- [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0)
-- [Gov Ops Manual](https://near-ndc.notion.site/NDC-V1-Ops-Manual-914bf75675284daf8314e1a05c0a2eea)
 - [Community Treasury](./community-treasury.md)
 - [List of links and documents](https://thewiki.near.page/gwg-docs)
 

--- a/framework-v1/README.md
+++ b/framework-v1/README.md
@@ -17,7 +17,7 @@ Links:
   - [voting details](./elections-voting.md)
 - [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0)
 - [Gov Ops Manual](https://docs.google.com/document/d/1l5g7JhaEPUMzjrzXEKw2Za5UmuRyK_9qxj-2-2CxlOE/edit?usp=drivesdk)
-- [Community Treasury](./framework-v1/community-treasury.md)
+- [Community Treasury](./community-treasury.md)
 - [List of links and documents](https://thewiki.near.page/gwg-docs)
 
 ## Important Dates
@@ -149,11 +149,12 @@ After the election results are announced, the elected representatives will conve
 
 ## References
 
-1. [NDC Overview Slides](https://docs.google.com/presentation/d/1YFzsBRB-UcZYN93tDVEHUGE7uGx2OuW61PnXsNMYgPU/edit?usp=sharing)
+1. [NDC Overview]( https://docs.google.com/presentation/d/1Vm12P-vMtaDHvK-gtFroW6PAQ6fis32SiGHbW2qYaGQ/edit?usp=sharing)
+1. [Ops Manual](https://near-ndc.notion.site/NDC-V1-Ops-Manual-914bf75675284daf8314e1a05c0a2eea)
 1. [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0/edit?pli=1) (outdated)
 1. [NDC Trust](https://bafybeic5s7qbf3dlbwqesv4byzc6llwpfx2kq36xzwfknu7sskxlanellm.ipfs.nftstorage.link/)
 1. [NEAR Constitution](./constitution.md)
-1. [Code of Conduct](https://medium.com/near-digital-collective/ndc-code-of-conduct-89589dd137ba)
+1. [Code of Conduct](./code-of-conduct.md)
 1. [Declaration of Transparency and Accountability](https://bafkreid3vx2tivdlwkivezalhkscxnxakirw5nuunxce3b6ivtx4j6ac44.ipfs.nftstorage.link/)
 1. [Fair Voting Policy](https://bafkreiapsavs6hrc6aomzagub7aumogkfbjewlo2tvwzesr4myshlecfqy.ipfs.nftstorage.link)
 1. [Whistleblower program](https://medium.com/@neardigitalcollective/introducing-ndc-whistleblower-bounty-program-d4fe1b9fc5a0)

--- a/framework-v1/README.md
+++ b/framework-v1/README.md
@@ -16,7 +16,7 @@ Links:
 - [Elections](#Elections)
   - [voting details](./elections-voting.md)
 - [NDC Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0)
-- [Gov Ops Manual](https://docs.google.com/document/d/1l5g7JhaEPUMzjrzXEKw2Za5UmuRyK_9qxj-2-2CxlOE/edit?usp=drivesdk)
+- [Gov Ops Manual](https://near-ndc.notion.site/NDC-V1-Ops-Manual-914bf75675284daf8314e1a05c0a2eea)
 - [Community Treasury](./community-treasury.md)
 - [List of links and documents](https://thewiki.near.page/gwg-docs)
 

--- a/framework-v1/code-of-conduct.md
+++ b/framework-v1/code-of-conduct.md
@@ -1,5 +1,8 @@
 # Code of Conduct
 
+Near Social [version](https://near.org/neardigitalcollective.near/widget/NDCDocs_OneArticle?articleId=CommunityGuidelines&blockHeight=91522833&lastEditor=neardigitalcollective.near
+).
+
 ## Introduction
 
 The NDC Community is made up of an amazing array of individuals and projects from different cultures and backgrounds. We strive to maintain a welcoming and respectful community for all members.

--- a/framework-v1/code-of-conduct.md
+++ b/framework-v1/code-of-conduct.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+## Introduction
+
+The NDC Community is made up of an amazing array of individuals and projects from different cultures and backgrounds. We strive to maintain a welcoming and respectful community for all members.
+Like any diverse community, it’s important there are rules in place to allow everyone to feel safe working towards building a decentralized future.
+The NDC has worked on versions of Codes of Conduct before. However, the GWG wanted to simplify them in places, and also provide guidance for how the community might handle bad actors, so there’s a section on that below.
+Perhaps most importantly, these guidelines should serve as a springboard for the community to gather around, and improve on with time.
+
+## NDC Community Code Of Conduct
+
+Let’s think about language
+
+- In dealing with people all around the world, we have to be cautious of the use of language. Language can be filled with historical baggage that can be interpreted as harmful or offensive to others.
+- This can be related, but not limited to, age, gender, religious, racial, economic status, social background, health, or sex.
+- If language does cause offense, it’s important to acknowledge that and find ways of working past it. That might not be possible, but as a first port of call, we all need to hold ourselves and each other to account.
+
+We’re not going to get it right the first time. But as a rule, the community endeavors to work towards understanding and acceptance.
+
+No to violence
+
+- The NDC community abhors violence in any form, and it has collective power to eject anyone from the community that either incites or commits those acts themselves.
+
+Don’t play the blame game
+
+- There’s a fine line between constructive criticism or feedback and attacks and or harassment. The community should endeavor to always be considerate of others when suggesting improvements, or discussing topics.
+- Providing repetitive criticism without showing intent to improve a situation, resolve a problem or help another person, is equal to complaining and considered toxic behavior. This will likely lead to defensive responses on the receiving end and is unlikely to lead to any valuable progress.
+- Lively conversations and feedback are essential to a healthy community. However, when this is not formulated in a constructive manner, moderators will intervene and forward the person providing the feedback to a sticky post on the forum. This can be found in the [gov forum](https://gov.near.org/t/gwg-ndc-constructive-feedback/33545).
+
+This is where feedback can be formulated in a constructive manner, provided with the right inputs to move things forward. Moderators will moderate the [community guidelines](https://gov.near.org/t/community-guidelines-march-2023/33544) post and flag any feedback to the appropriate individuals in order to address this feedback.
+
+### What happens when someone steps over the line?
+
+- With any community, be it digital or IRL, there needs to be a way of escalating issues or removing bad actors.
+- The NDC Mods are enforcing a three strikes and you’re out rule. So if a member of the community has received three strikes from moderators, they will be ejected from the community.
+- Warnings and bans will be documented in a to-be-created sticky topic on the NDC gov forum. This can be found at [Enforcing Community Guidelines: Warnings and Bans](https://gov.near.org/t/enforcing-community-guidelines-warnings-and-bans/33546). Documentation will consist of screenshot(s) of the offense and an explanation why a warning or ban is in place.
+- On special occasions, moderators hold the authority to ban users without warning if all mods unanimously agree that it is an appropriate penalty.
+- To make this enforceable, the NDC is currently exploring on-chain KYC toolkits that would make it difficult for ejected actors to re-enter the community using a different name.
+
+### Dispute resolution
+
+Whenever a community member is banned for breaking the Community Guidelines, they can dispute this once by requesting a public vote in the Telegram Group. Once NDCs Proof-of-Personhood (i-am-human) is live, this will be conducted on the appropriate platform (NEAR Social) to counter Sybil attacks.
+
+### Evolving the code of conduct
+
+This is a living document. This means that what is stated here will and can change, if the community deems it so.

--- a/framework-v1/gov-framework.md
+++ b/framework-v1/gov-framework.md
@@ -500,7 +500,7 @@ In addition, the governing bodies can, at any time, based on the feedback of the
 1. [NDC Overview Slides](https://docs.google.com/presentation/d/1YFzsBRB-UcZYN93tDVEHUGE7uGx2OuW61PnXsNMYgPU/edit?usp=sharing)
 2. [NDC Trust](https://bafybeic5s7qbf3dlbwqesv4byzc6llwpfx2kq36xzwfknu7sskxlanellm.ipfs.nftstorage.link/)
 3. [NEAR Constitution](./constitution.md)
-4. [Code of Conduct](https://medium.com/near-digital-collective/ndc-code-of-conduct-89589dd137ba)
+4. [Code of Conduct](https://bafybeifjibo3ygatrlpszzhqososzw3rlitrgdudkrc6fceo3musandgfm.ipfs.nftstorage.link)
 5. [Declaration of Transparency and Accountability](https://bafkreid3vx2tivdlwkivezalhkscxnxakirw5nuunxce3b6ivtx4j6ac44.ipfs.nftstorage.link/)
 6. [Fair Voting Policy](https://bafkreidwdxocdkfsv6srynw7ipnogfuw76fzncmxd5jv7furbsn5cp4bz4.ipfs.nftstorage.link/)
 7. [Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0/edit?pli=1) (outdated)

--- a/framework-v1/gov-framework.md
+++ b/framework-v1/gov-framework.md
@@ -1,10 +1,10 @@
 # A Framework for the Governing Bodies of the NEAR Digital Collective
 
-| Version: | Date:             | Status:                                            |
-| -------- | ----------------- | -------------------------------------------------- |
-| v1.2     | June 2, 2023      | Publicly Visible to NDC                            |
-| v1.3     | October 1, 2023   | Release Candidate                                  |
-| v1.4     | November 14, 2023 | Full Release                                       |
+| Version: | Date:             | Status:                                             |
+| -------- | ----------------- | --------------------------------------------------- |
+| v1.2     | June 2, 2023      | Publicly Visible to NDC                             |
+| v1.3     | October 1, 2023   | Release Candidate                                   |
+| v1.4     | November 14, 2023 | Full Release                                        |
 | v1.4.1   | November 23, 2023 | Fixes, reconciliation and added `min_vote_duration` |
 
 ## Summary
@@ -495,22 +495,4 @@ In addition, the governing bodies can, at any time, based on the feedback of the
 
 ---
 
-## References
-
-1. [NDC Overview Slides](https://docs.google.com/presentation/d/1YFzsBRB-UcZYN93tDVEHUGE7uGx2OuW61PnXsNMYgPU/edit?usp=sharing)
-2. [NDC Trust](https://bafybeic5s7qbf3dlbwqesv4byzc6llwpfx2kq36xzwfknu7sskxlanellm.ipfs.nftstorage.link/)
-3. [NEAR Constitution](./constitution.md)
-4. [Code of Conduct](https://bafybeifjibo3ygatrlpszzhqososzw3rlitrgdudkrc6fceo3musandgfm.ipfs.nftstorage.link)
-5. [Declaration of Transparency and Accountability](https://bafkreid3vx2tivdlwkivezalhkscxnxakirw5nuunxce3b6ivtx4j6ac44.ipfs.nftstorage.link/)
-6. [Fair Voting Policy](https://bafkreidwdxocdkfsv6srynw7ipnogfuw76fzncmxd5jv7furbsn5cp4bz4.ipfs.nftstorage.link/)
-7. [Product Book](https://docs.google.com/document/d/1w_wfRfp-ISH7g-zu7vAFULVvRNwyLGwNIDC1EBkxvu0/edit?pli=1) (outdated)
-8. [Voting Body](https://github.com/near-ndc/voting-v1/tree/master/voting_body) contract implementation.
-9. [Congress](https://github.com/near-ndc/voting-v1/tree/master/congress) (HoM, CoA, TC) contract implementation.
-
-### Tools:
-
-- [Astra++](https://near.org/astraplusplus.ndctools.near/widget/home?page=congress) - Congress, Voting Body, DAOs
-- [NDC Docs](https://near.org/neardigitalcollective.near/widget/NDCDocs) - post/edit final docs
-- [Easy Poll](https://near.org/easypoll-v0.ndc-widgets.near/widget/EasyPoll?page=official_polls) - Community pulse and sentiment
-- [NDC Chatbot](https://ndc-chatbot.nearhub.club/) - Ask questions
-- [Kudos](https://near.org/kudos.ndctools.near/widget/NDC.Kudos.Main) - appreciation and recognition
+## [References](./README.md#references)


### PR DESCRIPTION
In #7 a Code of Conduct link was fixed and updated to use medium. We should retain from using centralized services to store important documents. 
In this PR, CoC was moved to Github (not the best, but at least it's federated), and Near Social version is linked. 

Reference links have been unified and moved to the README file.